### PR TITLE
Modification destructeur

### DIFF
--- a/classes/Sql.php
+++ b/classes/Sql.php
@@ -42,6 +42,6 @@ class Sql
 
     public function __destruct()
     {
-        unset($this->connexion);
+        $this->connexion = null;
     }
 }


### PR DESCRIPTION
La destruction d'un objet PDO se fait par l'affectation de null à la variable représentant l'objet.
https://www.php.net/manual/en/pdo.connections.php